### PR TITLE
Change domain of Chaordic Search API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-## [0.0.3] - 2019-07-17
+## [0.0.3] - 2020-03-16
 ### Fixed
 - Changed Search's API domain to the new one 
 - Organizate GraphQL schema adding the types file
+
+## [0.0.2] - 2019
+
+## [0.0.1] - 2019

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
+and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.0.3] - 2019-07-17
+### Fixed
+- Changed Search's API domain to the new one 
+- Organizate GraphQL schema adding the types file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-
-## [0.0.3] - 2020-03-16
 ### Fixed
 - Changed Search's API domain to the new one 
-- Organizate GraphQL schema adding the types file
+- Organize GraphQL schema adding the types file
 
 ## [0.0.2] - 2019
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -1,311 +1,41 @@
-type ChaordicSearchOutput {
-	banners: [ChaordicSearchBanner]
-	quickFilters: [ChaordicSearchQuickFilter]
-	products: [ChaordicSearchProduct]
-	pagination: ChaordicSearchPagination
-	filters: [ChaordicSearchFilters]
-	queries: ChaordicSearchQueries
-	requestId: String
-	searchId: String
-	size: Int
-	queryType: String
-	link: String
-}
-
-type ChaordicSearchBanner {
-	position: String
-	content: String
-}
-
-type ChaordicSearchQuickFilter {
-	name: String
-	image: String
-}
-
-type ChaordicSearchProduct {
-  	cacheId: ID
-	cId: String
-	clickUrl: String
-	collectInfo: ChaordicSearchProductCollectionInfo
-	details: ChaordicSearchProductDetails
-	iId: Int
-	id: String
-	productId: String
-	images: ChaordicSearchProductImages
-	installment: ChaordicSearchProductInstallment
-	name: String
-	oldPrice: Float
-	price: Float
-	status: String
-	url: String
-}
-
-type ChaordicSearchProductCollectionInfo {
-	productId: String
-	skuList: [String]
-}
-
-#
-# Fields: Publico, InformacoesImportantes, FamiliaOlfativa, Video
-# Problem: Missing because accent.
-#
-
-type ChaordicSearchProductDetails {
-	referenceId: [String]
-	Publico: [String]
-	brand: [String]
-	Tamanho: [String]
-	InformacoesImportantes: [String]
-	FamiliaOlfativa: [String]
-	noiteBeleza: [String]
-	gid: [String]
-	blackWeek: [String]
-	freeShipping: [String]
-	yourviews: [String]
-	Video: [String]
-	clusterHighlights: [ChaordicSearchProductDetailsHighLight]
-}
-
-type ChaordicSearchProductDetailsHighLight {
-	name: String
-}
-
-type ChaordicSearchProductImages {
-	default: String
-}
-
-type ChaordicSearchProductInstallment {
-	price: Float
-	count: Int
-}
-
-type ChaordicSearchPagination {
-	first: String
-	next: String
-	last: String
-}
-
-type ChaordicSearchFilters {
-	attribute: String
-	fType: Int
-	id: Int
-	type: String
-	values: [ChaordicSearchFiltersValues]
-}
-
-type ChaordicSearchFiltersValues {
-	label: String
-    size: Int
-    id: Int
-    applyLink: String
-    unN: String
-    unityId: Int
-    min: ChaordicSearchFiltersValuesMin
-    max: ChaordicSearchFiltersValuesMax
-    idO: String
-	filters: [ChaordicSearchFiltersValuesFilters]
-}
-
-type ChaordicSearchFiltersValuesMin {
-	value: Float
-	unity: String
-	minN: Float
-}
-
-type ChaordicSearchFiltersValuesMax {
-	value: Float
-	unity: String
-	maxN: Float
-}
-
-type ChaordicSearchFiltersValuesFilters {
-	applyLink: String
-	filters: [ChaordicSearchFiltersValuesFilters]
-	id: Int
-	idO: String
-	label: String
-	size: Int
-}
-
-type ChaordicSearchQueries {
-	normalized: String
-	original: String
-	processed: String
-	queryType: String
-}
-
-type ChaordicSearchAutoCompleteOutput {
-	requestId: String
-	searchId: String
-	queries: [ChaordicSearchAutoCompleteQueries]
-	products: [ChaordicSearchProduct]
-}
-
-type ChaordicSearchAutoCompleteQueries {
-	query: String
-	link: String
-}
-
-type ChaordicSearchAutoCompletePopularOutput {
-	requestId: String
-	searchId: String
-	queries: [ChaordicSearchAutoCompleteQueries]
-}
-
-type ChaordicRecommendationsResult {
-  top: [ChaordicRecommendations]!
-  middle: [ChaordicRecommendations]!
-  bottom: [ChaordicRecommendations]!
-}
-
-type ChaordicRecommendations {
-  id: String!
-  title: String!
-  name: String!
-  feature: String!
-  impressionUrl: String!
-  subtitle: String
-  context: String!
-  displays: [ChaordicRecommendationsDisplays]!
-}
-
-type ChaordicProductPageRecommendations {
-  context: String!
-  displays: [ChaordicRecommendationsDisplays]!
-}
-
-type ChaordicRecommendationsDisplays {
-  references: [ChaordicProductPageRecommendationsProduct]!
-  recommendations: [ChaordicProductPageRecommendationsProduct]!
-}
-
-type ChaordicRecommendationsProduct {
-  id: String!
-  name: String!
-  price: Float!
-  oldPrice: Float
-  url: String!
-  images: ChaordicRecommendationsProductImages
-  brand: String
-  installment: ChaordicRecommendationsProductInstallment
-  status: String
-  categories: [ChaordicRecommendationsProductCategory]
-  details: ChaordicRecommendationsProductDetails
-  skus: [ChaordicRecommendationsSku]!
-  trackingUrl: String
-}
-
-type ChaordicProductPageRecommendationsProduct {
-  id: String!
-  name: String!
-  price: Float!
-  oldPrice: Float
-  url: String!
-  images: ChaordicRecommendationsProductImages
-  brand: String
-  installment: ChaordicProductPageRecommendationsProductInstallment
-  status: String
-  categories: [ChaordicRecommendationsProductCategory]
-  details: ChaordicRecommendationsProductDetails
-  skus: [ChaordicRecommendationsSku]!
-  trackingUrl: String
-}
-
-type ChaordicRecommendationsProductImages {
-  default: String
-  template: String
-  # TODO: Rename these fields for valid graphql identifiers, e.g. small, medium, large.
-  # _200x200: String
-  # _400x400: String
-  # _1000x1000: String
-}
-
-type ChaordicRecommendationsProductInstallment {
-	price: Float
-	count: Int
-}
-
-type ChaordicProductPageRecommendationsProductInstallment {
-	price: Float
-	count: Int
-}
-
-type ChaordicRecommendationsProductCategory {
-	id: String!
-	name: String!
-  parents: [String]
-}
-
-type ChaordicRecommendationsProductDetails {
-  Tamanho: [String]
-  Publico: [String]
-  InformacoesImportantes: [String]
-  brand: String
-  noiteBeleza: String
-  blackWeek: String
-  freeShipping: String
-}
-
-type ChaordicRecommendationsSku {
-  status: String!
-  url: String!
-  name: String!
-  sku: String!
-  images: ChaordicRecommendationsProductImages
-  installment: ChaordicRecommendationsProductInstallment
-  price: Float
-  stock: Int
-  details: ChaordicRecommendationsSkuDetail
-  specs: ChaordicRecommendationsSkuSpecs
-}
-
-type ChaordicRecommendationsProductSkus {
-  status: String!
-  url: String!
-  name: String!
-  images: ChaordicRecommendationsProductImages
-  installment: ChaordicRecommendationsProductInstallment
-  price: Float
-  stock: Int
-  details: ChaordicRecommendationsSkuDetail
-  sku: String
-  specs: ChaordicRecommendationsSkuSpecs
-}
-
-type ChaordicRecommendationsSkuDetail {
-  referenceId: String
-}
-
-type ChaordicRecommendationsSkuSpecs {
-  Cores: String
-}
-
 type Query {
   searchProducts(
-    terms: String = "",
-    page: Int = 1,
-    sortBy: String = "",
-    filter: String = "",
+    terms: String = ""
+    page: Int = 1
+    sortBy: String = ""
+    filter: String = ""
     resultsPerPage: Int = ""
-  ): ChaordicSearchOutput! @cacheControl(scope: PUBLIC, maxAge: SHORT) @withSecretKeys
+  ): ChaordicSearchOutput!
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @withSecretKeys
+
   searchProductsAutoComplete(
     terms: String = ""
-  ): ChaordicSearchAutoCompleteOutput! @cacheControl(scope: PUBLIC, maxAge: SHORT) @withSecretKeys
-  searchProductsAutoCompletePopular: ChaordicSearchAutoCompletePopularOutput! @withSecretKeys
+  ): ChaordicSearchAutoCompleteOutput!
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @withSecretKeys
+
+  searchProductsAutoCompletePopular: ChaordicSearchAutoCompletePopularOutput!
+    @withSecretKeys
 
   chaordicRecommendations(
-    chaordicBrowserId: String!,
-    pathName: String!,
-    source: String!,
-    name: String,
+    chaordicBrowserId: String!
+    pathName: String!
+    source: String!
+    name: String
     productId: String
-  ): ChaordicRecommendationsResult! @cacheControl(scope: PUBLIC, maxAge: SHORT) @withSecretKeys
+  ): ChaordicRecommendationsResult!
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @withSecretKeys
+
   chaordicProductPageRecommendations(
-    chaordicBrowserId: String!,
-    productId: String!,
-    type: String,
+    chaordicBrowserId: String!
+    productId: String!
+    type: String
     size: Int
-  ): ChaordicProductPageRecommendations! @cacheControl(scope: PUBLIC, maxAge: SHORT) @withSecretKeys
+  ): ChaordicProductPageRecommendations!
+    @cacheControl(scope: PUBLIC, maxAge: SHORT)
+    @withSecretKeys
 }
 
 type Mutation {

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1,0 +1,281 @@
+type ChaordicSearchOutput {
+  banners: [ChaordicSearchBanner]
+  quickFilters: [ChaordicSearchQuickFilter]
+  products: [ChaordicSearchProduct]
+  pagination: ChaordicSearchPagination
+  filters: [ChaordicSearchFilters]
+  queries: ChaordicSearchQueries
+  requestId: String
+  searchId: String
+  size: Int
+  queryType: String
+  link: String
+}
+
+type ChaordicSearchBanner {
+  position: String
+  content: String
+}
+
+type ChaordicSearchQuickFilter {
+  name: String
+  image: String
+}
+
+type ChaordicSearchProduct {
+  cacheId: ID
+  cId: String
+  clickUrl: String
+  collectInfo: ChaordicSearchProductCollectionInfo
+  details: ChaordicSearchProductDetails
+  iId: Int
+  id: String
+  productId: String
+  images: ChaordicSearchProductImages
+  installment: ChaordicSearchProductInstallment
+  name: String
+  oldPrice: Float
+  price: Float
+  status: String
+  url: String
+}
+
+type ChaordicSearchProductCollectionInfo {
+  productId: String
+  skuList: [String]
+}
+
+#
+# Fields: Publico, InformacoesImportantes, FamiliaOlfativa, Video
+# Problem: Missing because accent.
+#
+
+type ChaordicSearchProductDetails {
+  referenceId: [String]
+  Publico: [String]
+  brand: [String]
+  Tamanho: [String]
+  InformacoesImportantes: [String]
+  FamiliaOlfativa: [String]
+  noiteBeleza: [String]
+  gid: [String]
+  blackWeek: [String]
+  freeShipping: [String]
+  yourviews: [String]
+  Video: [String]
+  clusterHighlights: [ChaordicSearchProductDetailsHighLight]
+}
+
+type ChaordicSearchProductDetailsHighLight {
+  name: String
+}
+
+type ChaordicSearchProductImages {
+  default: String
+}
+
+type ChaordicSearchProductInstallment {
+  price: Float
+  count: Int
+}
+
+type ChaordicSearchPagination {
+  first: String
+  next: String
+  last: String
+}
+
+type ChaordicSearchFilters {
+  attribute: String
+  fType: Int
+  id: Int
+  type: String
+  values: [ChaordicSearchFiltersValues]
+}
+
+type ChaordicSearchFiltersValues {
+  label: String
+  size: Int
+  id: Int
+  applyLink: String
+  unN: String
+  unityId: Int
+  min: ChaordicSearchFiltersValuesMin
+  max: ChaordicSearchFiltersValuesMax
+  idO: String
+  filters: [ChaordicSearchFiltersValuesFilters]
+}
+
+type ChaordicSearchFiltersValuesMin {
+  value: Float
+  unity: String
+  minN: Float
+}
+
+type ChaordicSearchFiltersValuesMax {
+  value: Float
+  unity: String
+  maxN: Float
+}
+
+type ChaordicSearchFiltersValuesFilters {
+  applyLink: String
+  filters: [ChaordicSearchFiltersValuesFilters]
+  id: Int
+  idO: String
+  label: String
+  size: Int
+}
+
+type ChaordicSearchQueries {
+  normalized: String
+  original: String
+  processed: String
+  queryType: String
+}
+
+type ChaordicSearchAutoCompleteOutput {
+  requestId: String
+  searchId: String
+  queries: [ChaordicSearchAutoCompleteQueries]
+  products: [ChaordicSearchProduct]
+}
+
+type ChaordicSearchAutoCompleteQueries {
+  query: String
+  link: String
+}
+
+type ChaordicSearchAutoCompletePopularOutput {
+  requestId: String
+  searchId: String
+  queries: [ChaordicSearchAutoCompleteQueries]
+}
+
+type ChaordicRecommendationsResult {
+  top: [ChaordicRecommendations]!
+  middle: [ChaordicRecommendations]!
+  bottom: [ChaordicRecommendations]!
+}
+
+type ChaordicRecommendations {
+  id: String!
+  title: String!
+  name: String!
+  feature: String!
+  impressionUrl: String!
+  subtitle: String
+  context: String!
+  displays: [ChaordicRecommendationsDisplays]!
+}
+
+type ChaordicProductPageRecommendations {
+  context: String!
+  displays: [ChaordicRecommendationsDisplays]!
+}
+
+type ChaordicRecommendationsDisplays {
+  references: [ChaordicProductPageRecommendationsProduct]!
+  recommendations: [ChaordicProductPageRecommendationsProduct]!
+}
+
+type ChaordicRecommendationsProduct {
+  id: String!
+  name: String!
+  price: Float!
+  oldPrice: Float
+  url: String!
+  images: ChaordicRecommendationsProductImages
+  brand: String
+  installment: ChaordicRecommendationsProductInstallment
+  status: String
+  categories: [ChaordicRecommendationsProductCategory]
+  details: ChaordicRecommendationsProductDetails
+  skus: [ChaordicRecommendationsSku]!
+  trackingUrl: String
+}
+
+type ChaordicProductPageRecommendationsProduct {
+  id: String!
+  name: String!
+  price: Float!
+  oldPrice: Float
+  url: String!
+  images: ChaordicRecommendationsProductImages
+  brand: String
+  installment: ChaordicProductPageRecommendationsProductInstallment
+  status: String
+  categories: [ChaordicRecommendationsProductCategory]
+  details: ChaordicRecommendationsProductDetails
+  skus: [ChaordicRecommendationsSku]!
+  trackingUrl: String
+}
+
+type ChaordicRecommendationsProductImages {
+  default: String
+  template: String
+  # TODO: Rename these fields for valid graphql identifiers, e.g. small, medium, large.
+  # _200x200: String
+  # _400x400: String
+  # _1000x1000: String
+}
+
+type ChaordicRecommendationsProductInstallment {
+  price: Float
+  count: Int
+}
+
+type ChaordicProductPageRecommendationsProductInstallment {
+  price: Float
+  count: Int
+}
+
+type ChaordicRecommendationsProductCategory {
+  id: String!
+  name: String!
+  parents: [String]
+}
+
+type ChaordicRecommendationsProductDetails {
+  Tamanho: [String]
+  Publico: [String]
+  InformacoesImportantes: [String]
+  brand: String
+  noiteBeleza: String
+  blackWeek: String
+  freeShipping: String
+}
+
+type ChaordicRecommendationsSku {
+  status: String!
+  url: String!
+  name: String!
+  sku: String!
+  images: ChaordicRecommendationsProductImages
+  installment: ChaordicRecommendationsProductInstallment
+  price: Float
+  stock: Int
+  details: ChaordicRecommendationsSkuDetail
+  specs: ChaordicRecommendationsSkuSpecs
+}
+
+type ChaordicRecommendationsProductSkus {
+  status: String!
+  url: String!
+  name: String!
+  images: ChaordicRecommendationsProductImages
+  installment: ChaordicRecommendationsProductInstallment
+  price: Float
+  stock: Int
+  details: ChaordicRecommendationsSkuDetail
+  sku: String
+  specs: ChaordicRecommendationsSkuSpecs
+}
+
+type ChaordicRecommendationsSkuDetail {
+  referenceId: String
+}
+
+type ChaordicRecommendationsSkuSpecs {
+  Cores: String
+}

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "chaordic-graphql",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "builders": {
     "graphql": "1.x",
     "node": "4.x",
@@ -18,8 +18,8 @@
     {
       "name": "outbound-access",
       "attrs": {
-        "host": "{{account}}.neemu.com",
-        "path": "/searchapi/v3/*"
+        "host": "api.linximpulse.com",
+        "path": "engage/search/v3/*"
       }
     },
     {

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "chaordic-graphql",
-  "version": "0.0.3",
+  "version": "0.0.2",
   "builders": {
     "graphql": "1.x",
     "node": "4.x",

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -25,7 +25,7 @@ export default class Search extends ExternalClient {
   public secretKey?: string
 
   constructor(context: IOContext, options?: InstanceOptions) {
-    super(`http://${context.account}.neemu.com/searchapi/v3`, context, {
+    super(`https://api.linximpulse.com/engage/search/v3`, context, {
       ...options,
       headers: {
         'Accept':'application/json',


### PR DESCRIPTION
#### What problem is this solving?
Change path and domain of Chaordic Search API like the API docs: https://docs.linximpulse.com/v3-search/docs/search

#### How should this be manually tested?
1. Access: https://autocomplete--carrefourbrfood.myvtex.com/_v/private/carrefourbr.carrefour-search@0.0.1/graphiql/v1?operationName=chaordicAutocompletes&query=query%20chaordicAutocompletes%20%7B%0A%20%20searchProductsAutoCompletePopular%20%7B%0A%20%20%20%20requestId%0A%20%20%20%20searchId%0A%20%20%20%20queries%7B%0A%20%20%20%20%20%20query%0A%20%20%20%20%20%20link%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A
2. Play the query.

#### Checklist/Reminders

- [x] Updated `CHANGELOG.md`.
- [ ] Linked this PR to a Clubhouse story (if applicable).
- [ ] Updated/created tests (important for bug fixes).
- [ ] Deleted the workspace after merging this PR (if applicable).

#### Type of changes

✔️ | Bug fix <!-- a non-breaking change which fixes an issue -->
_ | New feature <!-- a non-breaking change which adds functionality -->
_ | Breaking change <!-- fix or feature that would cause existing functionality to change -->
_ | Technical improvements <!-- chores, refactors and overall reduction of technical debt -->
