### PR TITLE
Fix secretKeys encoding and add dummy and homologation params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix secretKeys encoding
 
 ## [0.0.3] - 2020-03-30
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Add dummy and homologation params
 ### Fixed
 - Fix secretKeys encoding
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- Add dummy and homologation params
+- Dummy and homologation params on Search and Recommendation
 ### Fixed
-- Fix secretKeys encoding
+- SecretKeys decoding from VBase
 
 ## [0.0.3] - 2020-03-30
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -35,5 +35,6 @@
   "settingsSchema": {},
   "scripts": {
     "postreleasy": "bash publish.sh"
-  }
+  },
+  "$schema": "https://raw.githubusercontent.com/vtex/node-vtex-api/master/gen/manifest.schema"
 }

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -30,7 +30,7 @@ export default class Recommendation extends ExternalClient {
     super('http://recs.chaordicsystems.com/v0', context, {
       ...options,
       headers: {
-        'Accept':'application/json',
+        'Accept': 'application/json',
         'Content-Type': 'application/json',
         'x-vtex-use-https': 'true',
       },
@@ -43,29 +43,35 @@ export default class Recommendation extends ExternalClient {
     this.secretKey = decodeURIComponent(secretKeys?.secretKey)
   }
 
-  public recommendations (params: RecommendationParams): Promise<any> {
+  public recommendations(params: RecommendationParams): Promise<any> {
     return this.get(this.routes.recommendations, { metric: 'chaordic-recommendations', params })
   }
 
-  public productRecommendations (params: ProductRecommendationParams): Promise<any> {
+  public productRecommendations(params: ProductRecommendationParams): Promise<any> {
     return this.get(this.routes.recommendations, { metric: 'chaordic-recommendations-product', params })
   }
 
-  public impression (impressionUrl: string): Promise<any> {
+  public impression(impressionUrl: string): Promise<any> {
     return this.get(impressionUrl, { metric: 'chaordic-recommendations-impression' })
   }
 
-  private get routes () {
+  private get routes() {
     return {
       recommendations: '/pages/recommendations/',
     }
   }
 
-  private get (url: string, config?: RequestConfig) {
+  private get(url: string, config?: RequestConfig) {
+    console.log(this.context)
+
     const params = {
       ...config && config.params,
       apiKey: this.apiKey,
       secretKey: this.secretKey,
+      ...(this.context.workspace !== 'master' && {
+        dummy: true,
+        homologation: true
+      })
     }
 
     return this.http.get(url, {

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -62,7 +62,6 @@ export default class Recommendation extends ExternalClient {
   }
 
   private get(url: string, config?: RequestConfig) {
-    console.log(this.context)
 
     const params = {
       ...config && config.params,

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -68,9 +68,9 @@ export default class Recommendation extends ExternalClient {
       ...config && config.params,
       apiKey: this.apiKey,
       secretKey: this.secretKey,
-      ...(this.context.workspace !== 'master' && {
+      ...(!this.context.production && {
         dummy: true,
-        homologation: true
+        homologation: true,
       })
     }
 

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -39,8 +39,8 @@ export default class Recommendation extends ExternalClient {
 
   // This is initialized by the withSecretKeys directive
   public init(secretKeys: SecretKeys) {
-    this.apiKey = secretKeys.apiKey
-    this.secretKey = secretKeys.secretKey
+    this.apiKey = secretKeys?.apiKey
+    this.secretKey = decodeURIComponent(secretKeys?.secretKey)
   }
 
   public recommendations (params: RecommendationParams): Promise<any> {

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -65,7 +65,7 @@ export default class Search extends ExternalClient {
       ...config && config.params,
       apiKey: this.apiKey,
       secretKey: this.secretKey,
-      ...(this.context.workspace !== 'master' && {
+      ...(!this.context.production && {
         dummy: true,
         homologation: true
       })

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -36,8 +36,8 @@ export default class Search extends ExternalClient {
 
   // This is initialized by the withSecretKeys directive
   public init(secretKeys: SecretKeys) {
-    this.apiKey = secretKeys.apiKey
-    this.secretKey = secretKeys.secretKey
+    this.apiKey = secretKeys?.apiKey
+    this.secretKey = decodeURIComponent(secretKeys?.secretKey)
   }
 
   public search (params: SearchParams): Promise<any> {

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -28,7 +28,7 @@ export default class Search extends ExternalClient {
     super(`https://api.linximpulse.com/engage/search/v3`, context, {
       ...options,
       headers: {
-        'Accept':'application/json',
+        'Accept': 'application/json',
         'Content-Type': 'application/json',
       },
     })
@@ -40,19 +40,19 @@ export default class Search extends ExternalClient {
     this.secretKey = decodeURIComponent(secretKeys?.secretKey)
   }
 
-  public search (params: SearchParams): Promise<any> {
+  public search(params: SearchParams): Promise<any> {
     return this.get(this.routes.search, { metric: 'chaordic-search', params })
   }
 
-  public autocomplete (params: AutocompleteParams): Promise<any> {
+  public autocomplete(params: AutocompleteParams): Promise<any> {
     return this.get(this.routes.autocomplete, { metric: 'chaordic-autocomplete', params })
   }
 
-  public popular (): Promise<any> {
+  public popular(): Promise<any> {
     return this.get(this.routes.popular, { metric: 'chaordic-popular' })
   }
 
-  private get routes () {
+  private get routes() {
     return {
       autocomplete: '/autocompletes',
       popular: '/autocompletes/popular',
@@ -60,11 +60,15 @@ export default class Search extends ExternalClient {
     }
   }
 
-  private get (url: string, config?: RequestConfig) {
+  private get(url: string, config?: RequestConfig) {
     const params = {
       ...config && config.params,
       apiKey: this.apiKey,
       secretKey: this.secretKey,
+      ...(this.context.workspace !== 'master' && {
+        dummy: true,
+        homologation: true
+      })
     }
 
     return this.http.get(url, {

--- a/node/package.json
+++ b/node/package.json
@@ -24,7 +24,7 @@
     "@vtex/api": "^3.8.1",
     "tslint": "^5.12.0",
     "tslint-config-vtex": "^2.1.0",
-    "typescript": "^3.4.2"
+    "typescript": "3.8.3"
   },
   "scripts": {
     "lint": "tsc --noEmit && tslint --fix -c tslint.json './**/*.ts'"

--- a/node/yarn.lock
+++ b/node/yarn.lock
@@ -1740,10 +1740,10 @@ type-is@^1.6.16:
     media-typer "0.3.0"
     mime-types "~2.1.18"
 
-typescript@^3.4.2:
-  version "3.4.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.4.5.tgz#2d2618d10bb566572b8d7aad5180d84257d70a99"
-  integrity sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==
+typescript@3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.8.3.tgz#409eb8544ea0335711205869ec458ab109ee1061"
+  integrity sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==
 
 universalify@^0.1.0:
   version "0.1.2"


### PR DESCRIPTION
Some secretKeys have characters that add a encode on parsing from VBase, this causes a request error, blocking the apiKey and secretKey.

![image](https://user-images.githubusercontent.com/49173685/78696737-3540e000-78d6-11ea-92c8-34d1c1aa7e68.png)

With this fixed, we added the dummy and homologation params to us can test in a non-integrated environment.

Link to tests:
https://gus--carrefourbrfood.myvtex.com/_v/private/carrefourbrfood.carrefour-search@0.0.1/graphiql/v1?query=query%20chaordicRecommendations(%24chaordicBrowserId%3A%20String!%2C%20%24pathName%3A%20String!%2C%20%24source%3A%20String!%2C%20%24name%3A%20String%2C%20%24productId%3A%20String)%20%7B%0A%09chaordicRecommendations(chaordicBrowserId%3A%20%24chaordicBrowserId%2C%20pathName%3A%20%24pathName%2C%20source%3A%20%24source%2C%20name%3A%20%24name%2C%20productId%3A%20%24productId)%20%7B%0A%20%20%20%20top%20%7B%0A%09%09%09id%0A%20%20%20%20%7D%0A%20%20%20%20middle%20%7B%0A%09%09%09id%0A%20%20%20%20%7D%0A%20%20%20%20bottom%20%7B%0A%09%09%09id%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D%0A&variables=%7B%0A%20%20%22chaordicBrowserId%22%3A%20%221%22%2C%0A%20%20%22pathName%22%3A%20%22%22%2C%0A%20%20%22source%22%3A%20%22desktop%22%2C%0A%20%20%22name%22%3A%20%22home%22%0A%7D&operationName=chaordicRecommendations