### PR TITLE
Change product's details to scalar types and add salesChannel param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Params `salesChannel` on all requests
 ### Fixed
 - Change product's details to scalar types
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-### Added
+### Changed
 - Params `salesChannel` on all requests
 ### Fixed
 - Change product's details to scalar types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Change product's details to scalar types
 
 ## [0.1.0] - 2020-04-07
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `oldPrice` on Product's Sku types
 ### Changed
 - Params `salesChannel` on all requests
 ### Fixed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -2,6 +2,7 @@ type Query {
   searchProducts(
     terms: String = ""
     page: Int = 1
+    salesChannel: String
     sortBy: String = ""
     filter: String = ""
     resultsPerPage: Int = ""
@@ -10,6 +11,7 @@ type Query {
     @withSecretKeys
 
   searchProductsAutoComplete(
+    salesChannel: String
     terms: String = ""
   ): ChaordicSearchAutoCompleteOutput!
     @cacheControl(scope: PUBLIC, maxAge: SHORT)
@@ -22,6 +24,7 @@ type Query {
     chaordicBrowserId: String!
     pathName: String!
     source: String!
+    salesChannel: String
     name: String
     productId: String
   ): ChaordicRecommendationsResult!
@@ -31,6 +34,7 @@ type Query {
   chaordicProductPageRecommendations(
     chaordicBrowserId: String!
     productId: String!
+    salesChannel: String
     type: String
     size: Int
   ): ChaordicProductPageRecommendations!

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -1,3 +1,11 @@
+scalar ChaordicSearchProductDetails
+
+scalar ChaordicRecommendationsSkuDetail
+
+scalar ChaordicRecommendationsSkuSpecs
+
+scalar ChaordicRecommendationsProductDetails
+
 type ChaordicSearchOutput {
   banners: [ChaordicSearchBanner]
   quickFilters: [ChaordicSearchQuickFilter]
@@ -49,22 +57,6 @@ type ChaordicSearchProductCollectionInfo {
 # Fields: Publico, InformacoesImportantes, FamiliaOlfativa, Video
 # Problem: Missing because accent.
 #
-
-type ChaordicSearchProductDetails {
-  referenceId: [String]
-  Publico: [String]
-  brand: [String]
-  Tamanho: [String]
-  InformacoesImportantes: [String]
-  FamiliaOlfativa: [String]
-  noiteBeleza: [String]
-  gid: [String]
-  blackWeek: [String]
-  freeShipping: [String]
-  yourviews: [String]
-  Video: [String]
-  clusterHighlights: [ChaordicSearchProductDetailsHighLight]
-}
 
 type ChaordicSearchProductDetailsHighLight {
   name: String
@@ -236,16 +228,6 @@ type ChaordicRecommendationsProductCategory {
   parents: [String]
 }
 
-type ChaordicRecommendationsProductDetails {
-  Tamanho: [String]
-  Publico: [String]
-  InformacoesImportantes: [String]
-  brand: String
-  noiteBeleza: String
-  blackWeek: String
-  freeShipping: String
-}
-
 type ChaordicRecommendationsSku {
   status: String!
   url: String!
@@ -270,12 +252,4 @@ type ChaordicRecommendationsProductSkus {
   details: ChaordicRecommendationsSkuDetail
   sku: String
   specs: ChaordicRecommendationsSkuSpecs
-}
-
-type ChaordicRecommendationsSkuDetail {
-  referenceId: String
-}
-
-type ChaordicRecommendationsSkuSpecs {
-  Cores: String
 }

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -236,6 +236,7 @@ type ChaordicRecommendationsSku {
   images: ChaordicRecommendationsProductImages
   installment: ChaordicRecommendationsProductInstallment
   price: Float
+  oldPrice: Float
   stock: Int
   details: ChaordicRecommendationsSkuDetail
   specs: ChaordicRecommendationsSkuSpecs
@@ -248,6 +249,7 @@ type ChaordicRecommendationsProductSkus {
   images: ChaordicRecommendationsProductImages
   installment: ChaordicRecommendationsProductInstallment
   price: Float
+  oldPrice: Float
   stock: Int
   details: ChaordicRecommendationsSkuDetail
   sku: String

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -4,6 +4,7 @@ export interface RecommendationParams {
   chaordicBrowserId?: string
   deviceId?: string
   name: string
+  salesChannel?: string
   pathName?: string
   productId: string
   productFormat?: string
@@ -13,6 +14,7 @@ export interface RecommendationParams {
 export interface ProductRecommendationParams {
   chaordicBrowserId?: string
   deviceId?: string
+  salesChannel?: string
   productId: string,
   size: number
   type: string,
@@ -70,7 +72,7 @@ export default class Recommendation extends ExternalClient {
       ...(!this.context.production && {
         dummy: true,
         homologation: true,
-      })
+      }),
     }
 
     return this.http.get(url, {

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -6,10 +6,12 @@ export interface SearchParams {
   resultsPerPage: number
   sortBy: string
   terms: string
+  salesChannel?: string
 }
 
 export interface AutocompleteParams {
   terms: string
+  salesChannel?: string
 }
 
 const treatedStatusCodes = [404, 302]
@@ -67,8 +69,8 @@ export default class Search extends ExternalClient {
       secretKey: this.secretKey,
       ...(!this.context.production && {
         dummy: true,
-        homologation: true
-      })
+        homologation: true,
+      }),
     }
 
     return this.http.get(url, {

--- a/node/resolvers/recommendations.ts
+++ b/node/resolvers/recommendations.ts
@@ -2,12 +2,13 @@ import { ImpressionParams, ProductRecommendationParams, RecommendationParams } f
 
 export const queries = {
   chaordicProductPageRecommendations: async (_: any, args: ProductRecommendationParams, ctx: Context) => {
-    const {clients: {recommendation}} = ctx
+    const { clients: { recommendation } } = ctx
 
     const {
       chaordicBrowserId,
       productId,
       type,
+      salesChannel,
       size,
     } = args
 
@@ -15,6 +16,7 @@ export const queries = {
       deviceId: chaordicBrowserId,
       productFormat: 'complete',
       productId,
+      salesChannel,
       size: size || 10,
       type: type || 'BestSellers',
     }
@@ -25,7 +27,7 @@ export const queries = {
   },
 
   chaordicRecommendations: async (_: any, args: RecommendationParams, ctx: Context) => {
-    const {clients: {recommendation}} = ctx
+    const { clients: { recommendation } } = ctx
     const forwardedHost = ctx.get('x-forwarded-host')
 
     const {
@@ -34,6 +36,7 @@ export const queries = {
       source,
       name,
       productId,
+      salesChannel,
     } = args
 
     const params = {
@@ -41,6 +44,7 @@ export const queries = {
       name: name || 'other',
       productFormat: 'complete',
       productId,
+      salesChannel,
       source,
       url: `https://${forwardedHost}` + pathName,
     }
@@ -53,7 +57,7 @@ export const queries = {
 
 export const mutations = {
   ChaordicImpression: async (_: any, args: ImpressionParams, ctx: Context) => {
-    const {clients: {recommendation}} = ctx
+    const { clients: { recommendation } } = ctx
 
     return recommendation.impression(args.impressionUrl)
       .then(() => true)


### PR DESCRIPTION
While many stores can use this repo and the `properties` from items can be different between them, its needs this types as `scalar` to make more flexible.

I've added to `salesChannel` params on all requests.

Link to test:
https://gus--carrefourbrfood.myvtex.com/_v/private/carrefourbrfood.carrefour-search@0.0.1/graphiql/v1?variables=%7B%0A%20%20%22chaordicBrowserId%22%3A%20%221%22%2C%0A%20%20%22pathName%22%3A%20%22%22%2C%0A%20%20%22source%22%3A%20%22desktop%22%2C%0A%20%20%22salesChannel%22%3A%20%22carrefourbr676%22%2C%0A%20%20%22name%22%3A%20%22home%22%0A%7D&operationName=chaordicRecommendations