### PR TITLE
New parameter `userId` to `chaordicRecommendations` query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New parameter `userId` to `chaordicRecommendations` query.
 
 ## [2.0.0] - 2020-05-05
 ### Changed

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -25,6 +25,7 @@ type Query {
     chaordicBrowserId: String!
     pathName: String!
     source: String!
+    userId: String
     salesChannel: String
     name: String
     productId: String

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -5,6 +5,7 @@ export interface RecommendationParams {
   deviceId?: string
   name: string
   salesChannel?: string
+  userId?: string
   pathName?: string
   productId: string
   productFormat?: string

--- a/node/resolvers/recommendations.ts
+++ b/node/resolvers/recommendations.ts
@@ -35,6 +35,7 @@ export const queries = {
       pathName,
       source,
       name,
+      userId,
       productId,
       salesChannel,
     } = args
@@ -47,6 +48,7 @@ export const queries = {
       salesChannel,
       source,
       url: `https://${forwardedHost}` + pathName,
+      userId,
     }
 
     ctx.set('cache-control', 'no-cache')


### PR DESCRIPTION
**What problem is this solving?**
Adds a param to improve the implementation of shelfs query.

**How to test**
https://gus--carrefourbrfood.myvtex.com/_v/private/vtex.chaordic-graphql@2.0.0/graphiql/v1?variables=%7B%22chaordicBrowserId%22%3A%22a20b6961-2f8a-4fdb-80e2-1173de4f4027%22%2C%22pathName%22%3A%22%2F%22%2C%22salesChannel%22%3A%222%22%2C%22source%22%3A%22desktop%22%2C%22name%22%3A%22home%22%2C%22userId%22%3A%2265192b13-7aa3-493a-b017-d72c26d7fbc9%22%7D&operationName=chaordicRecommendations