### PR TITLE
New param `showOnlyAvailable` to `chaordicRecommendations` query.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New param `showOnlyAvailable` to `chaordicRecommendations` query.
 
 ## [2.3.0] - 2020-05-26
 ### Added

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -22,6 +22,7 @@ type Query {
     @withSecretKeys
 
   chaordicRecommendations(
+    showOnlyAvailable: Boolean = true
     chaordicBrowserId: String!
     pathName: String!
     source: String!

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -102,6 +102,7 @@ export default class Recommendation extends ExternalClient {
       ...(!this.context.production && {
         dummy: true,
         homologation: true,
+        showOnlyAvailable: false,
       }),
     }
 

--- a/node/clients/recommendation.ts
+++ b/node/clients/recommendation.ts
@@ -17,6 +17,7 @@ export interface RecommendationParams {
   productId: string
   productFormat?: string
   source: string
+  showOnlyAvailable: boolean
 }
 
 export interface ProductRecommendationParams {

--- a/node/resolvers/recommendations.ts
+++ b/node/resolvers/recommendations.ts
@@ -49,15 +49,17 @@ export const queries = {
       userId,
       productId,
       salesChannel,
+      showOnlyAvailable
     } = args
 
     const params = {
+      category,
       deviceId: chaordicBrowserId,
       name: name || 'other',
       productFormat: 'complete',
       productId,
       salesChannel,
-      category,
+      showOnlyAvailable,
       source,
       url: `https://${forwardedHost}` + pathName,
       userId,


### PR DESCRIPTION
Link to test:
https://dev1004--carrefourbr.myvtex.com/_v/private/vtex.chaordic-graphql@2.3.0/graphiql/v1?operationName=chaordicRecommendations&variables=%7B%0A%22chaordicBrowserId%22%3A%20%22undefined%22%2C%0A%20%20%22pathName%22%3A%20%22%2F%22%2C%0A%20%20%22salesChannel%22%3A%20%221%22%2C%0A%20%20%22source%22%3A%20%22desktop%22%2C%0A%0A%22name%22%3A%20%22home%22%0A%0A%7D