### PR TITLE
Priorize sales channel as param

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Priorize parameter's `salesChannel`
+- Priorize `salesChannel` parameter 
 
 ## [2.5.0] - 2020-07-24
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+### Fixed
+- Priorize parameter's `salesChannel`
+
 ## [2.5.0] - 2020-07-24
 ### Added
 - Regionalization with VTEX white labels on requests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Unreleased]
 
 ### Fixed
-- Priorize `salesChannel` parameter 
+- Prioritize `salesChannel` parameter 
 
 ## [2.5.0] - 2020-07-24
 ### Added

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -65,7 +65,7 @@ export default class Search extends ExternalClient {
   }
 
   public popular(): Promise<any> {
-    return this.get(this.routes.popular, { metric: 'chaordic-popularq' })
+    return this.get(this.routes.popular, { metric: 'chaordic-popular' })
   }
 
   private get routes() {

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -65,7 +65,7 @@ export default class Search extends ExternalClient {
   }
 
   public popular(): Promise<any> {
-    return this.get(this.routes.popular, { metric: 'chaordic-popular' })
+    return this.get(this.routes.popular, { metric: 'chaordic-popularq' })
   }
 
   private get routes() {

--- a/node/resolvers/search.ts
+++ b/node/resolvers/search.ts
@@ -10,9 +10,12 @@ export const queries = {
     const {
       clients: { search },
     } = ctx
+
     return search.search({
       ...args,
-      salesChannel: formatSalesChannel(JSON.parse(atob(ctx.vtex.segmentToken))),
+      salesChannel:
+        args.salesChannel ??
+        formatSalesChannel(JSON.parse(atob(ctx.vtex.segmentToken))),
     })
   },
 


### PR DESCRIPTION
https://shelfregion--carrefourbrfood.myvtex.com/_v/private/vtex.chaordic-graphql@2.3.0/graphiql/v1?operationName=chaordicRecommendations&variables=%7B%0A%22chaordicBrowserId%22%3A%20%22undefined%22%2C%0A%20%20%22pathName%22%3A%20%22%2F%22%2C%0A%20%20%22salesChannel%22%3A%20%221%22%2C%0A%20%20%22source%22%3A%20%22desktop%22%2C%0A%0A%22name%22%3A%20%22home%22%0A%0A%7D'

I've added a nullish conditioner to prioritize when the salesChannel is sent on the search request