### PR TITLE
Feature/Adding Navigates endpoint of the Search API.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- `Navigates` endpoint of the `search` API.
 
 ## [2.5.1] - 2020-08-03
 

--- a/graphql/schema.graphql
+++ b/graphql/schema.graphql
@@ -44,6 +44,17 @@ type Query {
   ): ChaordicProductPageRecommendations!
     @cacheControl(scope: SEGMENT, maxAge: SHORT)
     @withSecretKeys
+
+   searchProductsNavigates(
+    fields: String,
+    category: String,
+    multicategory: [String],
+    page: Int = 1,
+    resultsPerPage: Int = 10,
+    sortBy: String = "relevance",
+    filter: String
+  ): ChaordicNavigatesOutput! @cacheControl(scope: PUBLIC, maxAge: SHORT) @withSecretKeys
+
 }
 
 type Mutation {

--- a/graphql/types.graphql
+++ b/graphql/types.graphql
@@ -294,3 +294,21 @@ type ChaordicRecommendationsProductSkus {
   sku: String
   specs: ChaordicRecommendationsSkuSpecs
 }
+
+type ChaordicSort {
+  label: String
+  name: String
+  type: String
+  applyLink: String
+}
+
+type ChaordicNavigatesOutput {
+  requestId: String
+  searchId: String
+  size: Int
+  name: String
+  sort: [ChaordicSort]
+  products: [ChaordicSearchProduct]
+  pagination: ChaordicSearchPagination
+  filters: [ChaordicSearchFilters]
+}

--- a/node/clients/search.ts
+++ b/node/clients/search.ts
@@ -20,6 +20,17 @@ export interface AutocompleteParams {
   salesChannel?: string
 }
 
+export interface NavigatesParams {
+  resultsPerPage: number
+  sortBy: string
+  filter: string
+  page: number
+  productFormat: string
+  fields: string
+  category: string
+  multicategory: string[]
+}
+
 const treatedStatusCodes = [404, 302]
 const treatedErrors = (e: any) => {
   if (
@@ -68,11 +79,19 @@ export default class Search extends ExternalClient {
     return this.get(this.routes.popular, { metric: 'chaordic-popular' })
   }
 
+  public navigates(params: NavigatesParams): Promise<any> {
+    return this.get(this.routes.navigates, {
+      metric: 'chaordic-navigates',
+      params,
+    })
+  }
+
   private get routes() {
     return {
       autocomplete: '/autocompletes',
       popular: '/autocompletes/popular',
       search: '/search',
+      navigates: '/navigates',
     }
   }
 

--- a/node/resolvers/search.ts
+++ b/node/resolvers/search.ts
@@ -1,7 +1,11 @@
 import { ResolverWarning } from '@vtex/api'
 import { prop, sortBy } from 'ramda'
 
-import { AutocompleteParams, SearchParams } from '../clients/search'
+import {
+  AutocompleteParams,
+  SearchParams,
+  NavigatesParams,
+} from '../clients/search'
 import { utf8ToChar } from '../utf8'
 import { formatSalesChannel, atob } from '../utils'
 
@@ -38,6 +42,38 @@ export const queries = {
       clients: { search },
     } = ctx
     return search.popular()
+  },
+
+  searchProductsNavigates: async (
+    _: any,
+    args: NavigatesParams,
+    ctx: Context
+  ) => {
+    const {
+      clients: { search },
+    } = ctx
+
+    const { fields, category, multicategory } = args
+
+    if (fields && (category || multicategory?.length)) {
+      throw new Error(
+        'The field "fields" cannot be used together with the category or multicategory field'
+      )
+      /*
+       * read more about this rule in the documentation: https://docs.linximpulse.com/v3-search/docs/navigate
+       */
+    }
+
+    if (category && multicategory?.length) {
+      throw new Error(
+        'The category and multicategory fields cannot be used together'
+      )
+      /*
+       * read more about this rule in the documentation: https://docs.linximpulse.com/v3-search/docs/navigate
+       */
+    }
+
+    return search.navigates(args)
   },
 }
 


### PR DESCRIPTION
#### What feature is being added?

Adding the `navigates` endpoint of the `search` API.

[Documentation](https://docs.linximpulse.com/v3-search/docs/navigate)

#### How to test it?

[GraphiQL](https://navigatechaordic--tokstokio.myvtex.com/_v/private/vtex.chaordic-graphql@2.5.1/graphiql/v1?operationName=searchProductsNavigates&query=query%20searchProductsNavigates(%24category%3A%20String%2C%20%24filter%3A%20String)%20%7B%0A%20%20searchProductsNavigates(category%3A%24category%2C%20filter%3A%20%24filter)%20%7B%0A%20%20%20%20products%20%7B%0A%20%20%20%20%20%20name%0A%20%20%20%20%20%20url%0A%20%20%20%20%7D%0A%20%20%20%20filters%20%7B%0A%20%20%20%20%20%20id%0A%20%20%20%20%20%20values%20%7B%0A%20%20%20%20%20%20%20%20id%0A%20%20%20%20%20%20%20%20label%0A%20%20%20%20%20%20%20%20size%0A%20%20%20%20%20%20%7D%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D&variables=%7B%0A%20%20%22category%22%3A%20%22moveis%22%2C%0A%20%20%22filter%22%3A%20%22d%3A8933%3AC%2FPalhinha%22%0A%7D)